### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "kormir"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64 0.13.1",
  "bitcoin 0.32.2",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "kormir-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "kormir-wasm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bip39",

--- a/kormir-server/CHANGELOG.md
+++ b/kormir-server/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/bennyhodl/kormir/compare/kormir-server-v0.3.0...kormir-server-v0.3.1) - 2024-11-27
+
+### Other
+
+- use ddk versions of rust-dlc
+- async ddk
+
 ## [0.3.0](https://github.com/bennyhodl/kormir/releases/tag/kormir-server-v0.3.0) - 2024-11-03
 
 ### Fixed

--- a/kormir-server/Cargo.toml
+++ b/kormir-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kormir-server"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["benthecarman <ben@mutinywallet.com>", "benny b <ben@bitcoinbay.foundation>"]
 description = "DLC Oracle RPC Server"
@@ -10,7 +10,7 @@ homepage = "https://github.com/bennyhodl/kormir"
 repository = "https://github.com/bennyhodl/kormir"
 
 [dependencies]
-kormir = { path = "../kormir", version = "0.3.1", features = ["nostr"] }
+kormir = { path = "../kormir", version = "0.3.2", features = ["nostr"] }
 
 anyhow = "1.0"
 axum = { version = "0.6.16", features = ["headers"] }

--- a/kormir-wasm/CHANGELOG.md
+++ b/kormir-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/bennyhodl/kormir/compare/kormir-wasm-v0.3.0...kormir-wasm-v0.3.1) - 2024-11-27
+
+### Other
+
+- use ddk versions of rust-dlc
+
 ## [0.3.0](https://github.com/bennyhodl/kormir/releases/tag/kormir-wasm-v0.3.0) - 2024-11-03
 
 ### Other

--- a/kormir-wasm/Cargo.toml
+++ b/kormir-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kormir-wasm"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["benthecarman <ben@mutinywallet.com>"]
 description = "DLC Oracle WASM SDK"
@@ -13,7 +13,7 @@ repository = "https://github.com/bennyhodl/kormir"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-kormir = { path = "../kormir", version = "0.3.1", features = ["nostr"] }
+kormir = { path = "../kormir", version = "0.3.2", features = ["nostr"] }
 
 anyhow = "1.0.75"
 bip39 = "2.0.0"

--- a/kormir/CHANGELOG.md
+++ b/kormir/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/bennyhodl/kormir/compare/kormir-v0.3.1...kormir-v0.3.2) - 2024-11-27
+
+### Other
+
+- use ddk versions of rust-dlc
+- async ddk
+
 ## [0.3.1](https://github.com/bennyhodl/kormir/compare/kormir-v0.3.0...kormir-v0.3.1) - 2024-11-03
 
 ### Other

--- a/kormir/Cargo.toml
+++ b/kormir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kormir"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["benthecarman <ben@mutinywallet.com>", "benny b <ben@bitcoinbay.foundation>"]
 description = "Oracle implementation for DLCs"


### PR DESCRIPTION
## 🤖 New release
* `kormir`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `kormir-server`: 0.3.0 -> 0.3.1
* `kormir-wasm`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `kormir`
<blockquote>

## [0.3.2](https://github.com/bennyhodl/kormir/compare/kormir-v0.3.1...kormir-v0.3.2) - 2024-11-27

### Other

- use ddk versions of rust-dlc
- async ddk
</blockquote>

## `kormir-server`
<blockquote>

## [0.3.1](https://github.com/bennyhodl/kormir/compare/kormir-server-v0.3.0...kormir-server-v0.3.1) - 2024-11-27

### Other

- use ddk versions of rust-dlc
- async ddk
</blockquote>

## `kormir-wasm`
<blockquote>

## [0.3.1](https://github.com/bennyhodl/kormir/compare/kormir-wasm-v0.3.0...kormir-wasm-v0.3.1) - 2024-11-27

### Other

- use ddk versions of rust-dlc
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).