### PR TITLE
feat: implement hmac authentication for create-* and sign-* endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,19 +161,19 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "headers",
- "http 0.2.11",
- "http-body",
- "hyper",
+ "http 1.0.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -185,28 +185,33 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.11",
- "http-body",
+ "http 1.0.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -422,9 +427,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cbc"
@@ -878,30 +883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
-dependencies = [
- "base64 0.21.5",
- "bytes",
- "headers-core",
- "http 0.2.11",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http 0.2.11",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +952,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,9 +994,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1000,16 +1004,35 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.11",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
 ]
 
 [[package]]
@@ -1020,10 +1043,26 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.11",
- "hyper",
+ "hyper 0.14.32",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.1",
+ "hyper 1.5.2",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1154,6 +1193,9 @@ dependencies = [
  "dotenv",
  "futures",
  "hex",
+ "hmac",
+ "http-body-util",
+ "hyper 1.5.2",
  "kormir",
  "log",
  "nostr",
@@ -1161,7 +1203,10 @@ dependencies = [
  "pretty_env_logger",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
+ "tower",
+ "tower-http",
 ]
 
 [[package]]
@@ -1591,26 +1636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,8 +1793,8 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.11",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -1783,7 +1808,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2162,16 +2187,6 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
@@ -2208,6 +2223,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "system-configuration"
@@ -2288,7 +2309,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -2402,14 +2423,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project",
  "pin-project-lite",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2417,16 +2438,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-layer"
-version = "0.3.2"
+name = "tower-http"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags 2.4.1",
+ "bytes",
+ "http 1.0.0",
+ "http-body 1.0.1",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/kormir-server/Cargo.toml
+++ b/kormir-server/Cargo.toml
@@ -13,7 +13,11 @@ repository = "https://github.com/bennyhodl/kormir"
 kormir = { path = "../kormir", version = "0.4.0", features = ["nostr"] }
 
 anyhow = "1.0"
-axum = { version = "0.6.16", features = ["headers"] }
+axum = "0.7.9"
+http-body-util = "0.1.0"
+hyper = "1.5.2"
+tower = "0.5.2"
+tower-http = { version = "0.6.2", features = ["timeout", "trace","map-request-body", "util"] }
 bitcoin = { version = "0.32.2", features = ["serde"] }
 chrono = { version = "0.4.26", features = ["serde"] }
 diesel = { version = "2.1", features = ["postgres", "r2d2", "chrono", "numeric"] }
@@ -30,3 +34,5 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0.67"
 tokio = { version = "1.12.0", features = ["full"] }
 hex = "0.4.3"
+hmac = "0.12.1"            # HMAC implementation
+sha2 = "0.10"            # SHA2 hash function (commonly used with HMAC)

--- a/kormir-server/src/routes.rs
+++ b/kormir-server/src/routes.rs
@@ -1,4 +1,4 @@
-use crate::State;
+use crate::AppState;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::http::StatusCode;
@@ -19,14 +19,14 @@ pub async fn health_check() -> Result<Json<()>, (StatusCode, String)> {
 }
 
 pub async fn get_pubkey(
-    Extension(state): Extension<State>,
+    Extension(state): Extension<AppState>,
 ) -> Result<Json<XOnlyPublicKey>, (StatusCode, String)> {
     Ok(Json(state.oracle.public_key()))
 }
 
 pub async fn list_events(
     Query(params): Query<HashMap<String, String>>,
-    Extension(state): Extension<State>,
+    Extension(state): Extension<AppState>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
     let events = state.oracle.storage.list_events().await.map_err(|_| {
         (
@@ -57,7 +57,7 @@ pub struct CreateEnumEvent {
     pub event_maturity_epoch: u32,
 }
 
-async fn create_enum_event_impl(state: &State, body: CreateEnumEvent) -> anyhow::Result<String> {
+async fn create_enum_event_impl(state: &AppState, body: CreateEnumEvent) -> anyhow::Result<String> {
     let ann = state
         .oracle
         .create_enum_event(
@@ -100,7 +100,7 @@ async fn create_enum_event_impl(state: &State, body: CreateEnumEvent) -> anyhow:
 }
 
 pub async fn create_enum_event(
-    Extension(state): Extension<State>,
+    Extension(state): Extension<AppState>,
     Json(body): Json<CreateEnumEvent>,
 ) -> Result<Json<String>, (StatusCode, String)> {
     if body.outcomes.is_empty() {
@@ -135,7 +135,7 @@ pub struct SignEnumEvent {
     pub outcome: String,
 }
 
-async fn sign_enum_event_impl(state: &State, body: SignEnumEvent) -> anyhow::Result<String> {
+async fn sign_enum_event_impl(state: &AppState, body: SignEnumEvent) -> anyhow::Result<String> {
     let att = state
         .oracle
         .sign_enum_event(body.event_id.clone(), body.outcome)
@@ -178,7 +178,7 @@ async fn sign_enum_event_impl(state: &State, body: SignEnumEvent) -> anyhow::Res
 }
 
 pub async fn sign_enum_event(
-    Extension(state): Extension<State>,
+    Extension(state): Extension<AppState>,
     Json(body): Json<SignEnumEvent>,
 ) -> Result<Json<String>, (StatusCode, String)> {
     match sign_enum_event_impl(&state, body).await {
@@ -204,7 +204,7 @@ pub struct CreateNumericEvent {
 }
 
 async fn create_numeric_event_impl(
-    state: &State,
+    state: &AppState,
     body: crate::routes::CreateNumericEvent,
 ) -> anyhow::Result<String> {
     let ann = state
@@ -252,7 +252,7 @@ async fn create_numeric_event_impl(
 }
 
 pub async fn create_numeric_event(
-    Extension(state): Extension<State>,
+    Extension(state): Extension<AppState>,
     Json(body): Json<crate::routes::CreateNumericEvent>,
 ) -> Result<Json<String>, (StatusCode, String)> {
     if body.num_digits.is_some() && body.num_digits.unwrap() == 0 {
@@ -282,7 +282,7 @@ pub async fn create_numeric_event(
 }
 
 pub async fn get_oracle_announcement_impl(
-    state: &State,
+    state: &AppState,
     event_id: String,
 ) -> anyhow::Result<OracleAnnouncement> {
     if let Some(event) = state.oracle.storage.get_event(event_id).await? {
@@ -295,7 +295,7 @@ pub async fn get_oracle_announcement_impl(
 }
 
 pub async fn get_oracle_announcement(
-    Extension(state): Extension<State>,
+    Extension(state): Extension<AppState>,
     Path(event_id): Path<String>,
 ) -> Result<Json<OracleAnnouncement>, (StatusCode, String)> {
     match crate::routes::get_oracle_announcement_impl(&state, event_id).await {
@@ -311,7 +311,7 @@ pub async fn get_oracle_announcement(
 }
 
 pub async fn get_oracle_attestation_impl(
-    state: &State,
+    state: &AppState,
     event_id: String,
 ) -> anyhow::Result<OracleAttestation> {
     let Some(event) = state.oracle.storage.get_event(event_id.clone()).await? else {
@@ -339,7 +339,7 @@ pub async fn get_oracle_attestation_impl(
 }
 
 pub async fn get_oracle_attestation(
-    Extension(state): Extension<State>,
+    Extension(state): Extension<AppState>,
     Path(event_id): Path<String>,
 ) -> Result<Json<OracleAttestation>, (StatusCode, String)> {
     match crate::routes::get_oracle_attestation_impl(&state, event_id).await {
@@ -361,7 +361,7 @@ pub struct SignNumericEvent {
 }
 
 async fn sign_numeric_event_impl(
-    state: &State,
+    state: &AppState,
     body: crate::routes::SignNumericEvent,
 ) -> anyhow::Result<String> {
     let att = state
@@ -406,7 +406,7 @@ async fn sign_numeric_event_impl(
 }
 
 pub async fn sign_numeric_event(
-    Extension(state): Extension<State>,
+    Extension(state): Extension<AppState>,
     Json(body): Json<crate::routes::SignNumericEvent>,
 ) -> Result<Json<String>, (StatusCode, String)> {
     match crate::routes::sign_numeric_event_impl(&state, body).await {


### PR DESCRIPTION
This PR introduces a simple out-of-the-box HMAC authentication and authorization scheme for write operations, which are currently wide open. 

It introduces a non-optional `KORMIR_HMAC_SECRET` environment variable to define an HMAC secret. Authentication can be disabled by setting the `KORMIR_HMAC_SECRET` environment variable to `none`.

The server expects the client to send a hex-encoded HMAC signature, generated using the same secret, in the `X-Signature` HTTP request header.