### PR TITLE
chore: return the oracle info struct in kormir-server

### DIFF
--- a/kormir-server/src/json_models.rs
+++ b/kormir-server/src/json_models.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use bitcoin::XOnlyPublicKey;
 use chrono::{SecondsFormat, TimeZone, Utc};
 use dlc_messages::oracle_msgs::{OracleAnnouncement, OracleAttestation};
 use dlc_messages::ser_impls::write_as_tlv;
@@ -6,6 +7,11 @@ use kormir::lightning::util::ser::Writeable;
 use kormir::storage::OracleEventData;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PubkeyResponse {
+    pub pubkey: XOnlyPublicKey,
+}
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct CreateEnumEventRequest {

--- a/kormir-server/src/json_models.rs
+++ b/kormir-server/src/json_models.rs
@@ -1,0 +1,133 @@
+use anyhow::anyhow;
+use chrono::{SecondsFormat, TimeZone, Utc};
+use dlc_messages::oracle_msgs::{OracleAnnouncement, OracleAttestation};
+use dlc_messages::ser_impls::write_as_tlv;
+use kormir::lightning::util::ser::Writeable;
+use kormir::storage::OracleEventData;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateEnumEventRequest {
+    pub event_id: String,
+    pub outcomes: Vec<String>,
+    pub event_maturity_epoch: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SignEnumEventRequest {
+    pub event_id: String,
+    pub outcome: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateNumericEventRequest {
+    pub event_id: String,
+    pub num_digits: Option<u16>,
+    pub is_signed: Option<bool>,
+    pub precision: Option<i32>,
+    pub unit: String,
+    pub event_maturity_epoch: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SignNumericEventRequest {
+    pub event_id: String,
+    pub outcome: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonEventResponse {
+    pub announcement: OracleAnnouncement,
+    pub attestation: Option<OracleAttestation>,
+}
+
+impl From<OracleEventData> for JsonEventResponse {
+    fn from(d: OracleEventData) -> Self {
+        JsonEventResponse {
+            attestation: d.attestation(),
+            announcement: d.announcement,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HexEventResponse {
+    pub event_id: String,
+    pub event_maturity_epoch: u32,
+    pub event_maturity_iso: String,
+    pub announcement: String,
+    pub attestation: Option<String>,
+}
+
+impl From<OracleEventData> for HexEventResponse {
+    fn from(d: OracleEventData) -> Self {
+        let attestation = d.attestation();
+        HexEventResponse {
+            event_id: d.announcement.oracle_event.event_id.clone(),
+            event_maturity_epoch: d.announcement.oracle_event.event_maturity_epoch,
+            event_maturity_iso: epoch_to_iso(d.announcement.oracle_event.event_maturity_epoch),
+            announcement: hex::encode(d.announcement.encode()),
+            attestation: attestation.map(|a| hex::encode(a.encode())),
+        }
+    }
+}
+
+fn epoch_to_iso(epoch: u32) -> String {
+    Utc.timestamp_nanos(epoch as i64 * 1_000_000_000)
+        .to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TLVEventResponse {
+    pub event_id: String,
+    pub event_maturity_epoch: u32,
+    pub event_maturity_iso: String,
+    pub announcement: String,
+    pub attestation: Option<String>,
+}
+
+impl From<OracleEventData> for TLVEventResponse {
+    fn from(d: OracleEventData) -> Self {
+        let attestation = d.attestation();
+        TLVEventResponse {
+            event_id: d.announcement.oracle_event.event_id.clone(),
+            event_maturity_epoch: d.announcement.oracle_event.event_maturity_epoch,
+            event_maturity_iso: epoch_to_iso(d.announcement.oracle_event.event_maturity_epoch),
+            announcement: {
+                let mut bytes = Vec::new();
+                write_as_tlv(&d.announcement, &mut bytes).unwrap();
+                hex::encode(bytes)
+            },
+            attestation: attestation.map(|a| {
+                let mut bytes = Vec::new();
+                write_as_tlv(&a, &mut bytes).unwrap();
+                hex::encode(bytes)
+            }),
+        }
+    }
+}
+
+pub enum Format {
+    Json,
+    Hex,
+    Tlv,
+}
+
+impl Format {
+    pub fn from_query(params: &HashMap<String, String>) -> anyhow::Result<Self> {
+        if let Some(format) = params.get("format") {
+            if format == "json" {
+                Ok(Format::Json)
+            } else if format == "hex" {
+                Ok(Format::Hex)
+            } else if format == "tlv" {
+                Ok(Format::Tlv)
+            } else {
+                Err(anyhow!("invalid format: {format}"))
+            }
+        } else {
+            Ok(Format::Json)
+        }
+    }
+}

--- a/kormir-server/src/main.rs
+++ b/kormir-server/src/main.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use tokio::signal;
 use tower_http::timeout::TimeoutLayer;
 
+mod json_models;
 mod models;
 mod routes;
 

--- a/kormir-server/src/routes.rs
+++ b/kormir-server/src/routes.rs
@@ -5,7 +5,6 @@ use axum::extract::Path;
 use axum::extract::Query;
 use axum::http::StatusCode;
 use axum::{Extension, Json};
-use bitcoin::key::XOnlyPublicKey;
 use dlc_messages::oracle_msgs::OracleAnnouncement;
 use kormir::storage::{OracleEventData, Storage};
 use kormir::OracleAttestation;
@@ -20,8 +19,10 @@ pub async fn health_check() -> Result<Json<()>, (StatusCode, String)> {
 
 pub async fn get_pubkey(
     Extension(state): Extension<AppState>,
-) -> Result<Json<XOnlyPublicKey>, (StatusCode, String)> {
-    Ok(Json(state.oracle.public_key()))
+) -> Result<Json<PubkeyResponse>, (StatusCode, String)> {
+    Ok(Json(PubkeyResponse {
+        pubkey: state.oracle.public_key(),
+    }))
 }
 
 pub async fn list_events(

--- a/kormir-wasm/src/models.rs
+++ b/kormir-wasm/src/models.rs
@@ -185,16 +185,10 @@ impl From<(String, OracleEventData)> for EventData {
             }
         };
 
-        let (attestation, observed_outcome) = match value.signatures.len() {
-            0 => (None, None),
-            _ => {
+        let (attestation, observed_outcome) = match value.attestation() {
+            None => (None, None),
+            Some(attestation) => {
                 // todo proper sorting for non-enum events
-                let attestation = OracleAttestation {
-                    event_id: value.announcement.oracle_event.event_id.clone(),
-                    oracle_public_key: value.announcement.oracle_public_key,
-                    signatures: value.signatures.iter().map(|x| x.1).collect(),
-                    outcomes: value.signatures.iter().map(|x| x.0.clone()).collect(),
-                };
                 let attestation = hex::encode(attestation.encode());
                 let outcome = match &value.announcement.oracle_event.event_descriptor {
                     EventDescriptor::EnumEvent(_) => {

--- a/kormir/src/storage.rs
+++ b/kormir/src/storage.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use bitcoin::secp256k1::schnorr::Signature;
-use dlc_messages::oracle_msgs::OracleAnnouncement;
+use dlc_messages::oracle_msgs::{OracleAnnouncement, OracleAttestation};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -40,6 +40,21 @@ pub struct OracleEventData {
     pub announcement_event_id: Option<String>,
     #[cfg(feature = "nostr")]
     pub attestation_event_id: Option<String>,
+}
+
+impl OracleEventData {
+    pub fn attestation(&self) -> Option<OracleAttestation> {
+        if self.signatures.is_empty() {
+            None
+        } else {
+            Some(OracleAttestation {
+                event_id: self.announcement.oracle_event.event_id.clone(),
+                oracle_public_key: self.announcement.oracle_public_key,
+                signatures: self.signatures.iter().map(|x| x.1).collect(),
+                outcomes: self.signatures.iter().map(|x| x.0.clone()).collect(),
+            })
+        }
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Fixes https://github.com/bennyhodl/kormir/issues/24

Sample output of `/create-enum` and `/announcement`

```json
{
  "announcementSignature": "affab11446617018efddde0f4e6ab0cf0cb8ddd3dc19be723edcb57ec6e46926cec7c7c05ab9de5999ca0d484d42e314f1b1294d5025fa2ca07c20b5442e88bb",
  "oraclePublicKey": "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e",
  "oracleEvent": {
    "oracleNonces": [
      "c2d0b9e9342693770d738cfcd069bc6339f030be21935e3c85d57ec3e08fc0d4"
    ],
    "eventMaturityEpoch": 1738884967,
    "eventDescriptor": {
      "enumEvent": {
        "outcomes": [
          "a",
          "b"
        ]
      }
    },
    "eventId": "enum"
  }
}
```

Sample output of `/sign-enum` and `/attestation`

```json
{
  "eventId": "enum",
  "oraclePublicKey": "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e",
  "signatures": [
    "c2d0b9e9342693770d738cfcd069bc6339f030be21935e3c85d57ec3e08fc0d413b01af856909cdc1231d1dc384c77a16438b8f970c696809ad0cc895c80941e"
  ],
  "outcomes": [
    "b"
  ]
}
```

Sample output of `/create-numeric` and `/announcement`

```json
{
  "announcementSignature": "1459c2d6c0da571ba0a69265e5c4175bfca8221a05184c7ae63d65c54c3b77ced2dd603a66ad01aff14e074c68b7a147944ad7ec5ed847b1dac63f319c3749b2",
  "oraclePublicKey": "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e",
  "oracleEvent": {
    "oracleNonces": [
      "a6a1f4ba811a2f8616fa32882d5903d56b076bf16afb7670ac958e287cfcf12b",
      "07e3f6c6f040b5cd304bed6603284295c0716de64e8442012ba3851c1665e7f6",
      "75e9e385e8151c5c81f6c14082a995dc9e24e1a75121a1ff3d06b31fb1dc824c",
      "71244aa64a6a542d6311dd4fe21dd44986d13c6c7b2e35818024ac3b369615ee",
      "123282ff00304ee83f6ad1510d54926e8976699a1f44f6ab80d81a5caf97c714",
      "21fa5029d9e8febb956e21a214494cde47584f71f23b2d131db598317550687d",
      "916ec8667200ec63edde56b0d761d005543848d287f0f346af2c59f6d3b8ae5a",
      "658ed1bdae800b8c257ce0d4aa0a4f87b8c643b55165235c917d3241b21040f6",
      "b6911c0b3eaf93b1f1a4c7d7a8bbb6d573b9d38b3e152084d1b1f69ff84eb3d7",
      "b4ee33f48cc2247f2b83747a177f72820e792d4ace8a0b6a30c029d6a0cd0c3e",
      "52cca6d6f8220747a643517e4d9a9fa5cf52251edd1c8ebb29aded230ce8e557",
      "ab1647c20e5977455eb76fc0cdba2493f29eebd9d0dea78997f6041f2cb9c619",
      "cd8d508a6a71c21d361f2ff02985bcbcef302df92b3b29f1a56d04817fc4f403",
      "fdd3fe05a982983a7798a1111f5179a6e9d0eec03153b448c4d39a4b86648187",
      "afbf40b41aac957511b4fa0a7fdad7c0a49dd7d4e06287f789b92a689d1337ef",
      "dbb1f9170028875599339a080a555b9de6fafdab5b2827daf58bd0e422d81473",
      "b0b895c684a59fb4482f6902052571bb33941ec132a2839ad45ca1077b9f5998",
      "cff164d7b78b7924aea33fc9fd74549ea4f18a40731210f5dd7b8f27081c45f7",
      "2b2cff0fd3f1186a592fd3e1a5f0a72927fd7d79e055efccc1edad7eb8cbccad"
    ],
    "eventMaturityEpoch": 1738880124,
    "eventDescriptor": {
      "digitDecompositionEvent": {
        "base": 2,
        "isSigned": true,
        "unit": "m/s",
        "precision": 0,
        "nbDigits": 18
      }
    },
    "eventId": "numeric"
  }
}
```

Sample output of `/sign-numeric` and `/attestation`

```json
{
  "eventId": "numeric",
  "oraclePublicKey": "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e",
  "signatures": [
    "a6a1f4ba811a2f8616fa32882d5903d56b076bf16afb7670ac958e287cfcf12b03301753f2efff1627566b6d56f504cc394cc852aef8501f7b011e910eba57f8",
    "07e3f6c6f040b5cd304bed6603284295c0716de64e8442012ba3851c1665e7f67ca7e3d7f4f29e559b6544617f6d856766633513806654956e4ad38591ab0c32",
    "75e9e385e8151c5c81f6c14082a995dc9e24e1a75121a1ff3d06b31fb1dc824c0d972980cb53a764daef0d1cd24efe7f807fdfeea47c08dd573728b98283e4ca",
    "71244aa64a6a542d6311dd4fe21dd44986d13c6c7b2e35818024ac3b369615ee7637d0e96c39b5831640a359c78d2daf2f600a5117ba46e02c979c1c5d712eca",
    "123282ff00304ee83f6ad1510d54926e8976699a1f44f6ab80d81a5caf97c714dd1bde553256cdac2616be2f1c7d916978d814356fc7779e40415571386b4e33",
    "21fa5029d9e8febb956e21a214494cde47584f71f23b2d131db598317550687dd17224d6ed64e3903a37a20de03c91d4a42b4173adf59052f67a079746150b22",
    "916ec8667200ec63edde56b0d761d005543848d287f0f346af2c59f6d3b8ae5afeb455c4bc3fe3e05690bb4080ab54ae9614990d046df890a10a5a6e53449e0b",
    "658ed1bdae800b8c257ce0d4aa0a4f87b8c643b55165235c917d3241b21040f6d89703f0c3b716cde6b965fb3ea1d0be542000866a76295afdd842e9dc2b96da",
    "b6911c0b3eaf93b1f1a4c7d7a8bbb6d573b9d38b3e152084d1b1f69ff84eb3d75541193cfedf474a312710c6a2dd485deb78e5bc23646b0609dba75c8d38a912",
    "b4ee33f48cc2247f2b83747a177f72820e792d4ace8a0b6a30c029d6a0cd0c3e1c0826260eea6dda25d53658e5694271bf7baa23807b30ed73761c165168ed10",
    "52cca6d6f8220747a643517e4d9a9fa5cf52251edd1c8ebb29aded230ce8e557e18ae8c0e3959513abfc528dfc234c904436771d7e09aeefce9c5b014c097a60",
    "ab1647c20e5977455eb76fc0cdba2493f29eebd9d0dea78997f6041f2cb9c6198888b9f0079b88fb665b9fe3e34ede6bfbbe2661c663a1827abaa1c4832ac821",
    "cd8d508a6a71c21d361f2ff02985bcbcef302df92b3b29f1a56d04817fc4f40317ef877f8a5d62ef6ebb527335738b283812aafa40947e976d0cfa1ebfedf177",
    "fdd3fe05a982983a7798a1111f5179a6e9d0eec03153b448c4d39a4b866481871ec28780922c0a95757299041973b252b430eb6e507d56a6994cbd849e8b23f8",
    "afbf40b41aac957511b4fa0a7fdad7c0a49dd7d4e06287f789b92a689d1337ef6fd40ba0c072768c27615b03b3ed73b3fb0dc1584a8e29383cd15d6cb87530f5",
    "dbb1f9170028875599339a080a555b9de6fafdab5b2827daf58bd0e422d81473d9d2faf72bb087ad69e1667446eb4c079796d93848a968f109efa7fa1c3446e5",
    "b0b895c684a59fb4482f6902052571bb33941ec132a2839ad45ca1077b9f5998093164abb7441210ee76fe2ebf25cc49056d3d3871b049ff2f0a7a2eb9600845",
    "cff164d7b78b7924aea33fc9fd74549ea4f18a40731210f5dd7b8f27081c45f76497ccb3dccbfdf152b143dfd0cd90200bf4a6d45e9f401a7e2ad1a4d86aaf76",
    "2b2cff0fd3f1186a592fd3e1a5f0a72927fd7d79e055efccc1edad7eb8cbccadaffd95ae1f98a8e2267d598a28e8105be9501b698a35d649d8f81ea5853923e9"
  ],
  "outcomes": [
    "-",
    "0",
    "1",
    "1",
    "0",
    "0",
    "0",
    "0",
    "1",
    "1",
    "0",
    "1",
    "0",
    "1",
    "0",
    "0",
    "0",
    "0",
    "0"
  ]
}
```