### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "kormir"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64 0.13.1",
  "bitcoin 0.32.2",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "kormir-server"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "kormir-wasm"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "bip39",

--- a/kormir-server/CHANGELOG.md
+++ b/kormir-server/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/bennyhodl/kormir/compare/kormir-server-v0.3.3...kormir-server-v0.3.4) - 2025-01-17
+
+### Added
+
+- implement hmac authentication for create-* and sign-* endpoints
+
+### Other
+
+- return pubkey struct
+- return the oracle info struct in kormir-server
+
 ## [0.3.1](https://github.com/bennyhodl/kormir/compare/kormir-server-v0.3.0...kormir-server-v0.3.1) - 2024-11-27
 
 ### Other

--- a/kormir-server/Cargo.toml
+++ b/kormir-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kormir-server"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["benthecarman <ben@mutinywallet.com>", "benny b <ben@bitcoinbay.foundation>"]
 description = "DLC Oracle RPC Server"
@@ -10,7 +10,7 @@ homepage = "https://github.com/bennyhodl/kormir"
 repository = "https://github.com/bennyhodl/kormir"
 
 [dependencies]
-kormir = { path = "../kormir", version = "0.4.0", features = ["nostr"] }
+kormir = { path = "../kormir", version = "0.4.2", features = ["nostr"] }
 
 anyhow = "1.0"
 axum = "0.7.9"

--- a/kormir-wasm/CHANGELOG.md
+++ b/kormir-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/bennyhodl/kormir/compare/kormir-wasm-v0.3.3...kormir-wasm-v0.3.4) - 2025-01-17
+
+### Other
+
+- return the oracle info struct in kormir-server
+
 ## [0.3.1](https://github.com/bennyhodl/kormir/compare/kormir-wasm-v0.3.0...kormir-wasm-v0.3.1) - 2024-11-27
 
 ### Other

--- a/kormir-wasm/Cargo.toml
+++ b/kormir-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kormir-wasm"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["benthecarman <ben@mutinywallet.com>"]
 description = "DLC Oracle WASM SDK"
@@ -13,7 +13,7 @@ repository = "https://github.com/bennyhodl/kormir"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-kormir = { path = "../kormir", version = "0.4.0", features = ["nostr"] }
+kormir = { path = "../kormir", version = "0.4.2", features = ["nostr"] }
 
 anyhow = "1.0.75"
 bip39 = "2.0.0"

--- a/kormir/CHANGELOG.md
+++ b/kormir/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/bennyhodl/kormir/compare/kormir-v0.4.1...kormir-v0.4.2) - 2025-01-17
+
+### Other
+
+- return the oracle info struct in kormir-server
+
 ## [0.3.2](https://github.com/bennyhodl/kormir/compare/kormir-v0.3.1...kormir-v0.3.2) - 2024-11-27
 
 ### Other

--- a/kormir/Cargo.toml
+++ b/kormir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kormir"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["benthecarman <ben@mutinywallet.com>", "benny b <ben@bitcoinbay.foundation>"]
 description = "Oracle implementation for DLCs"


### PR DESCRIPTION
## 🤖 New release
* `kormir`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `kormir-server`: 0.3.3 -> 0.3.4
* `kormir-wasm`: 0.3.3 -> 0.3.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `kormir`
<blockquote>

## [0.4.2](https://github.com/bennyhodl/kormir/compare/kormir-v0.4.1...kormir-v0.4.2) - 2025-01-17

### Other

- return the oracle info struct in kormir-server
</blockquote>

## `kormir-server`
<blockquote>

## [0.3.4](https://github.com/bennyhodl/kormir/compare/kormir-server-v0.3.3...kormir-server-v0.3.4) - 2025-01-17

### Added

- implement hmac authentication for create-* and sign-* endpoints

### Other

- return pubkey struct
- return the oracle info struct in kormir-server
</blockquote>

## `kormir-wasm`
<blockquote>

## [0.3.4](https://github.com/bennyhodl/kormir/compare/kormir-wasm-v0.3.3...kormir-wasm-v0.3.4) - 2025-01-17

### Other

- return the oracle info struct in kormir-server
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).